### PR TITLE
update faraday dependency

### DIFF
--- a/faraday_timing_middleware.gemspec
+++ b/faraday_timing_middleware.gemspec
@@ -19,10 +19,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', '~> 0.9'
+  spec.add_dependency 'faraday', '~> 1.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.8'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 0'
-  spec.add_development_dependency 'webmock', '~> 0'
+  spec.add_development_dependency 'bundler', '~> 2.2'
+  spec.add_development_dependency 'rake', '~> 13'
+  spec.add_development_dependency 'rspec', '~> 3'
+  spec.add_development_dependency 'webmock', '~> 3'
 end


### PR DESCRIPTION
Attempting to update our rails apps to use `sentry-rails` instead of `sentry-raven` and noticed this gem had a hard dependency on `faraday < 1.0` and decided to update it.